### PR TITLE
Fixed a missing interpolation operator

### DIFF
--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -30,13 +30,13 @@
 
         public const string NewDefinition = "Initialize a basic .NET project";
 
-        public const string RestoreDefinition = "Restore dependencies specified in the.NET project";
+        public const string RestoreDefinition = "Restore dependencies specified in the .NET project";
 
         public const string BuildDefinition = "Builds a .NET project";
 
         public const string PublishDefinition = "Publishes a .NET project for deployment (including the runtime)";
 
-        public const string RunDefinition = "Compiles and immediately executes a.NET project";
+        public const string RunDefinition = "Compiles and immediately executes a .NET project";
 
         public const string TestDefinition = "Runs unit tests using the test runner specified in the project";
 

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Restore
             cmd.HelpOption("-h|--help");
 
             var argRoot = cmd.Argument(
-                    "[{LocalizableStrings.CmdArgument}]",
+                    $"[{LocalizableStrings.CmdArgument}]",
                     LocalizableStrings.CmdArgumentDescription,
                     multipleValues: true);
 


### PR DESCRIPTION
Missed an interpolation $ operator in front of one of the translated commands.

